### PR TITLE
Add MPS support for Apple silicon

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ These results underscore HRM’s potential as a transformative advancement towar
 
 ### Prerequisites ⚙️
 
-Ensure PyTorch and CUDA are installed. The repo needs CUDA extensions to be built. If not present, run the following commands:
+Ensure PyTorch is installed. The repo supports CUDA and Apple silicon's Metal Performance Shaders (MPS) for acceleration.
+For NVIDIA GPUs, install CUDA and build the extensions with the commands below. For Apple silicon, see the MPS section after.
 
 ```bash
 # Install CUDA 12.6
@@ -31,6 +32,19 @@ pip3 install torch torchvision torchaudio --index-url $PYTORCH_INDEX_URL
 # Additional packages for building extensions
 pip3 install packaging ninja wheel setuptools setuptools-scm
 ```
+
+On Apple silicon, CUDA is not required. Install the PyTorch build with MPS support and optionally enable CPU fallback for
+unsupported operations:
+
+```bash
+# Install PyTorch with MPS support
+pip3 install torch torchvision torchaudio
+
+# Optional: allow CPU fallback for missing ops
+export PYTORCH_ENABLE_MPS_FALLBACK=1
+```
+
+The training scripts automatically select the MPS device when available.
 
 Then install FlashAttention. For Hopper GPUs, install FlashAttention 3
 

--- a/evaluate.py
+++ b/evaluate.py
@@ -5,6 +5,14 @@ import os
 import torch
 import torch.distributed as dist
 
+# Select device: prefer CUDA, then Apple MPS, otherwise CPU
+if torch.cuda.is_available():
+    DEVICE = "cuda"
+elif torch.backends.mps.is_available():  # type: ignore[attr-defined]
+    DEVICE = "mps"
+else:
+    DEVICE = "cpu"
+
 import pydantic
 from omegaconf import OmegaConf
 from pretrain import PretrainConfig, init_train_state, evaluate, create_dataloader
@@ -24,12 +32,13 @@ def launch():
     # Initialize distributed training if in distributed environment (e.g. torchrun)
     if "LOCAL_RANK" in os.environ:
         # Initialize distributed, default device and dtype
-        dist.init_process_group(backend="nccl")
+        dist.init_process_group(backend="nccl" if DEVICE == "cuda" else "gloo")
 
         RANK = dist.get_rank()
         WORLD_SIZE = dist.get_world_size()
 
-        torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
+        if DEVICE == "cuda":
+            torch.cuda.set_device(int(os.environ["LOCAL_RANK"]))
 
     with open(os.path.join(os.path.dirname(eval_cfg.checkpoint), "all_config.yaml"), "r") as f:
         config = PretrainConfig(**yaml.safe_load(f))
@@ -45,9 +54,9 @@ def launch():
     train_state = init_train_state(config, train_metadata, world_size=WORLD_SIZE)
     # Try unwrap torch.compile
     try:
-        train_state.model.load_state_dict(torch.load(eval_cfg.checkpoint, map_location="cuda"), assign=True)
+        train_state.model.load_state_dict(torch.load(eval_cfg.checkpoint, map_location=DEVICE), assign=True)
     except:
-        train_state.model.load_state_dict({k.removeprefix("_orig_mod."): v for k, v in torch.load(eval_cfg.checkpoint, map_location="cuda").items()}, assign=True)
+        train_state.model.load_state_dict({k.removeprefix("_orig_mod."): v for k, v in torch.load(eval_cfg.checkpoint, map_location=DEVICE).items()}, assign=True)
     
     train_state.step = 0
     ckpt_filename = os.path.basename(eval_cfg.checkpoint)


### PR DESCRIPTION
## Summary
- Detect and select CUDA, MPS, or CPU at runtime
- Move batches and models to the chosen device and select appropriate distributed backend
- Document how to use MPS on Apple silicon

## Testing
- `python -m py_compile pretrain.py evaluate.py`


------
https://chatgpt.com/codex/tasks/task_e_68a9393ccfbc83269051a75eef34fe65

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added Apple Silicon (MPS) acceleration support.
  - Automatic device selection (CUDA > MPS > CPU) for training and evaluation.
  - Distributed backend chosen automatically based on device.
  - Model loading now works seamlessly across devices.

- Documentation
  - Updated prerequisites to explicitly include Apple Silicon (MPS) alongside CUDA.
  - Added setup steps for installing PyTorch with MPS support.
  - Noted automatic MPS device selection and optional CPU fallback via PYTORCH_ENABLE_MPS_FALLBACK=1.
  - Clarified CUDA remains fully supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->